### PR TITLE
Set up design discussion hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # landmark-design-lab
-Design lab for landmark DS and UX
+
+This repository acts as a hub for design decisions and UX documentation.
+
+## How to use this repo
+
+1. **Issues** – Create a new issue for each design problem, feedback request, or decision thread. Summarize the question, add screenshots or Figma links, and capture the final outcome once decided.
+2. **Discussions** – Use the Discussions tab for open-ended conversations or proposals that may evolve over time.
+3. **Docs** – Store finalized decisions and design documentation in markdown files under the folders in this repo.
+
+## Directory structure
+
+- `component-decisions/` – Markdown files describing individual component decisions.
+- `critique-log/` – Notes from design critique sessions.
+- `docs/` – Living documentation about the design system.
+
+Everything in this repo is version controlled so you can track changes to your design process over time.

--- a/component-decisions/tooltip.md
+++ b/component-decisions/tooltip.md
@@ -1,0 +1,10 @@
+# Tooltip Component Decisions
+
+Use this file to document major design choices for the tooltip component.
+
+- **Decision Date:** 2025-06-15
+- **Context:** See the design exploration in [Figma](https://www.figma.com/).
+
+## Summary
+
+Summarize the final decision once it's reached.

--- a/critique-log/2025-06-tooltip-round.md
+++ b/critique-log/2025-06-tooltip-round.md
@@ -1,0 +1,10 @@
+# Tooltip Critique Session - June 2025
+
+Document the feedback gathered from the design critique session on tooltips.
+
+- **Participants:** TBD
+- **Assets:** [Figma link](https://www.figma.com/)
+
+## Notes
+
+Write notes from the critique here.

--- a/docs/pattern-library-overview.md
+++ b/docs/pattern-library-overview.md
@@ -1,0 +1,6 @@
+# Pattern Library Overview
+
+This living document describes the components and patterns used across the Landmark design system.
+
+- Use GitHub issues for discussions around updates.
+- Document finalized patterns here with links back to relevant issues or discussions.


### PR DESCRIPTION
## Summary
- establish directories for decisions, docs, and critique logs
- create initial doc placeholders
- explain how to use issues, discussions, and docs in the README

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684177001f5083288c990f2e281249fc