### PR TITLE
Improve design doc templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # landmark-design-lab
-Design lab for landmark DS and UX
+
+This repository acts as a hub for design decisions and UX documentation.
+
+## How to use this repo
+
+1. **Issues** – Create a new issue for each design problem, feedback request, or decision thread. Summarize the question, add screenshots or Figma links, and capture the final outcome once decided.
+2. **Discussions** – Use the Discussions tab for open-ended conversations or proposals that may evolve over time.
+3. **Docs** – Store finalized decisions and design documentation in markdown files under the folders in this repo.
+
+## Directory structure
+
+- `component-decisions/` – Markdown files describing individual component decisions.
+- `critique-log/` – Notes from design critique sessions.
+- `docs/` – Living documentation about the design system.
+
+Everything in this repo is version controlled so you can track changes to your design process over time.

--- a/component-decisions/tooltip.md
+++ b/component-decisions/tooltip.md
@@ -1,0 +1,23 @@
+# Tooltip Component Decisions 🛠️
+
+This page tracks major design choices for the Tooltip component so we have a clear record of what was explored and why we landed on the final solution.
+
+- **Decision Date:** 2025-06-15
+- **Context:** See the design exploration in [Figma](https://www.figma.com/).
+- **Status:** In review
+
+## Requirements
+
+- ✨ Must support keyboard focus
+- 📱 Works on touch devices
+- 🎨 Visual style aligns with brand guidelines
+
+## Explorations
+
+1. **Hover vs. Click** – a hover-only approach didn’t work for mobile.
+2. **Animation timing** – tested 100ms, 150ms, and 200ms fades; 150ms felt best.
+3. **Placement options** – default to top, but auto-adjust to avoid clipping.
+
+## Final Decision ✅
+
+When the design review is complete, capture the final choice here. Link back to the issue or discussion where the decision was made.

--- a/critique-log/2025-06-tooltip-round.md
+++ b/critique-log/2025-06-tooltip-round.md
@@ -1,0 +1,19 @@
+# Tooltip Critique Session – June 2025 ✨
+
+Record the discussion from our June critique on the new tooltip patterns.
+
+- **Date:** 2025-06-12
+- **Participants:** @designerA, @designerB
+- **Assets:** [Figma link](https://www.figma.com/)
+
+## Agenda 📝
+- Review color contrast updates
+- Decide on animation speed
+
+## Feedback 🙌
+- Contrast with dark background passed WCAG AA
+- 150ms animation felt crisp and unobtrusive
+
+## Action Items 🔧
+1. Update docs with final contrast ratios
+2. Provide a motion spec sheet

--- a/docs/pattern-library-overview.md
+++ b/docs/pattern-library-overview.md
@@ -1,0 +1,11 @@
+# Pattern Library Overview 📚
+
+This living document describes the components and patterns used in the Landmark Design System. Each pattern links back to the issue or discussion where it was finalized.
+
+## Example Structure
+
+- **Navigation** – See issue #12 for the decision on off-canvas vs dropdown.
+- **Forms** – Spacing rules documented in `/component-decisions/forms.md`.
+- **Tooltips** – Finalized approach captured in `/component-decisions/tooltip.md`.
+
+Update this overview whenever a new pattern is agreed upon so everyone has a single reference. ✨


### PR DESCRIPTION
## Summary
- flesh out `tooltip.md` with structured example sections and emojis
- expand critique log template for June 2025 session
- update pattern library overview with links and emoji

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684177001f5083288c990f2e281249fc